### PR TITLE
Use Arr and Str instead of helper methods which are deprecated

### DIFF
--- a/src/package/Support/File.php
+++ b/src/package/Support/File.php
@@ -2,6 +2,8 @@
 
 namespace PragmaRX\Yaml\Package\Support;
 
+use Illuminate\Support\Str;
+
 class File
 {
     /**
@@ -15,8 +17,8 @@ class File
     {
         return
             is_dir($item) &&
-            !ends_with($item, DIRECTORY_SEPARATOR.'.') &&
-            !ends_with($item, DIRECTORY_SEPARATOR.'..');
+            !Str::endsWith($item, DIRECTORY_SEPARATOR.'.') &&
+            !Str::endsWith($item, DIRECTORY_SEPARATOR.'..');
     }
 
     /**
@@ -54,8 +56,8 @@ class File
     {
         return
             $this->isFile($item) && (
-                ends_with(strtolower($item), '.yml') ||
-                ends_with(strtolower($item), '.yaml')
+                Str::endsWith(strtolower($item), '.yml') ||
+                Str::endsWith(strtolower($item), '.yaml')
             );
     }
 

--- a/src/package/Support/Resolver.php
+++ b/src/package/Support/Resolver.php
@@ -2,6 +2,7 @@
 
 namespace PragmaRX\Yaml\Package\Support;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 class Resolver
@@ -176,7 +177,7 @@ class Resolver
         preg_match_all("/\{\{'((?:[^{}]|(?R))*)\'\}\}/", $string, $matches);
 
         foreach ($matches[0] as $key => $value) {
-            $string = str_replace($matches[0][$key], array_get($keys->toArray(), $matches[1][$key]), $string);
+            $string = str_replace($matches[0][$key], Arr::get($keys->toArray(), $matches[1][$key]), $string);
         }
 
         return $string;

--- a/tests/YamlTest.php
+++ b/tests/YamlTest.php
@@ -2,6 +2,7 @@
 
 namespace PragmaRX\Yaml\Tests;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use PragmaRX\Yaml\Package\Exceptions\InvalidYamlFile;
 use PragmaRX\Yaml\Package\Exceptions\MethodNotFound;
@@ -109,7 +110,7 @@ class YamlTest extends TestCase
     {
         $array = $this->yaml->parseFile(__DIR__.'/stubs/conf/multiple/second-level/third-level/app.yml');
 
-        $this->assertEquals('Brazil Third Level', array_get($array, 'person.address.country'));
+        $this->assertEquals('Brazil Third Level', Arr::get($array, 'person.address.country'));
     }
 
     public function test_method_not_found()


### PR DESCRIPTION
The helper methods like `ends_with` are deprecated since Laravel 5.8. I have replaced those with the static calls to ensure compatibility with Laravel 6.