### PR TITLE
Add error information when YAML cannot be parsed

### DIFF
--- a/src/package/Support/Parser.php
+++ b/src/package/Support/Parser.php
@@ -75,7 +75,11 @@ class Parser
                 (new SymfonyParser())->parseFile($filename, $flags)
             );
         } catch (\Symfony\Component\Yaml\Exception\ParseException $exception) {
-            throw new InvalidYamlFile();
+            throw new InvalidYamlFile(
+                sprintf('%s is not valid YAML: %s', $filename, $exception->getMessage()),
+                $exception->getCode(),
+                $exception
+            );
         }
     }
 


### PR DESCRIPTION
I think it would be more convenient if the error information is output when YAML cannot be parsed.
Especially when a directory is specified for the `loadToConfig` method.

Here's an example:
```
PragmaRX/Yaml/Package/Exceptions/InvalidYamlFile with message '/var/app/src/mylaravel/config/myconfig/someconfig.yml is not valid YAML: Duplicate key "92" detected at line 363 (near "92: 'bar'").'
```