### PR TITLE
Merge with the Laravel config with the same name

### DIFF
--- a/src/package/Support/Resolver.php
+++ b/src/package/Support/Resolver.php
@@ -131,7 +131,7 @@ class Resolver
                 $this->recursivelyFindAndReplaceExecutableCode($contents)
             );
 
-            config([$configKey => $contents->toArray()]);
+            config([$configKey => array_merge($contents->toArray(), config($configKey, []))]);
         } while ($this->replaced > 0);
 
         return $contents;

--- a/tests/YamlTest.php
+++ b/tests/YamlTest.php
@@ -58,6 +58,21 @@ class YamlTest extends TestCase
         $this->assertEquals('Benoit', config('multiple.second-level.third-level.alter.person.name'));
     }
 
+    public function test_can_load_and_merge_with_laravel_config()
+    {
+        $laravelConfig1 = ['key' => 'value'];
+        $laravelConfig2 = ['key' => 'value'];
+        config(['mix.alter' => $laravelConfig1]);
+        config(['mix.second-level.third-level.alter' => $laravelConfig2]);
+
+        $this->yaml->loadToConfig(__DIR__.'/stubs/conf/multiple', 'mix');
+
+        $this->assertEquals($laravelConfig1, config('mix.alter'));
+        $this->assertEquals(config('multiple.app'), config('mix.app'));
+        $this->assertEquals($laravelConfig2, config('mix.second-level.third-level.alter'));
+        $this->assertNull(config('mix.second-level.third-level.app'));
+    }
+
     public function test_can_list_files()
     {
         $this->assertEquals(3, $this->yaml->listFiles(__DIR__.'/stubs/conf/multiple')->count());


### PR DESCRIPTION
I expect to be merged with the Laravel config with the same name.

This is my use case:

Laravel PHP config file and YAML config file are in the same directory.
```
laravel
└── config
    └── myapp
        ├── config1.php
        └── config2.yaml
```
I want to get both configs with the same name `myapp`.
```php
<?php

Yaml::loadToConfig(config_path('myapp'), 'myapp');
```
Currently, config in the `config1.php` file is removed from the Laravel config.
```php
<?php

// Currently
config('myapp.config1'); // => Return null
config('myapp.config2'); // => Return config in config2.yaml

// I expect it
config('myapp.config1'); // => Return config in config1.php
config('myapp.config2'); // => Return config in config2.yaml
```