### PR TITLE
Tune performance

### DIFF
--- a/src/package/Support/File.php
+++ b/src/package/Support/File.php
@@ -96,8 +96,6 @@ class File
      */
     public function cleanKey($key)
     {
-        return is_string($key) && file_exists(trim($key))
-            ? preg_replace('/\.[^.]+$/', '', basename($key))
-            : $key;
+        return preg_replace('/\.[^.]+$/', '', basename($key));
     }
 }

--- a/src/package/Yaml.php
+++ b/src/package/Yaml.php
@@ -107,11 +107,9 @@ class Yaml
      */
     public function loadToConfig($path, $configKey)
     {
-        $loaded = $this->cleanArrayKeysRecursive(
-            $this->file->isYamlFile($path)
-                ? $this->loadFile($path)
-                : $this->loadFromDirectory($path)
-        );
+        $loaded = $this->file->isYamlFile($path)
+            ? $this->loadFile($path)
+            : $this->loadFromDirectory($path);
 
         return $this->resolver->findAndReplaceExecutableCodeToExhaustion($loaded, $configKey);
     }
@@ -146,26 +144,6 @@ class Yaml
         }
 
         return $this->parser->parseFile($file);
-    }
-
-    /**
-     * Remove extension from file name.
-     *
-     * @param $dirty
-     *
-     * @return \Illuminate\Support\Collection|mixed
-     */
-    public function cleanArrayKeysRecursive($dirty)
-    {
-        if (is_array($dirty instanceof Collection ? $dirty->toArray() : $dirty)) {
-            return collect($dirty)->mapWithKeys(function ($item, $key) {
-                return [
-                    $this->file->cleanKey($key) => $this->cleanArrayKeysRecursive($item),
-                ];
-            });
-        }
-
-        return $dirty;
     }
 
     /**


### PR DESCRIPTION
This is a performance tuning pull request.

It took me about _0.5 seconds_ to call the `Yaml::loadToConfig` method from my Laravel project's `AppServiceProvider::boot` method.
After performance tuning it was less than _0.2 seconds_.

The environment of my project is as follows:
- Docker for Mac
- PHP 7.4.5
- Laravel 6.18.14
- YAML 1.1.0

YAML files of my project are as follows:
- 22 files
- About 200 lines per file on average

The reason the `Yaml::loadToConfig` method is slow seems to be that the `file_exists` function in the `File::cleanKey` method is called for many keys in memory.

This seems unnecessary to me.
The reason is that this is only needed when we specify a directory for the `Yaml::loadToConfig` method, but in this case it seems to be cleaned up by calling the `File::cleanKey` method in the `File::listFiles` method.

Please review it.