### PR TITLE
Add support for the PECL YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
+  - printf '\n' | pecl install yaml
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
 script:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ And it's merged to your Laravel config:
 config('my-package.name');
 ```
 
+## Utilize PECL YAML
+
+To utilize the PECL YAML, you should [install the PECL YAML extension](https://www.php.net/manual/en/yaml.installation.php) and register the binding in the `register()` method of your service provider:
+
+```php
+$this->app->bind(\PragmaRX\Yaml\Package\Support\Parser::class, \PragmaRX\Yaml\Package\Support\PeclParser::class);
+```
+
 ## Example
 
 This is a YAML file from another package using this package:

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
             }
         }
     },
+    "suggest": {
+        "ext-yaml": "Required to use the PECL YAML."
+    },
     "scripts": {
         "test": [
             "@composer install",

--- a/src/package/ServiceProvider.php
+++ b/src/package/ServiceProvider.php
@@ -3,6 +3,8 @@
 namespace PragmaRX\Yaml\Package;
 
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use PragmaRX\Yaml\Package\Support\Parser;
+use PragmaRX\Yaml\Package\Support\SymfonyParser;
 
 class ServiceProvider extends IlluminateServiceProvider
 {
@@ -28,8 +30,9 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     private function registerService()
     {
-        $this->app->singleton('pragmarx.yaml', function () {
-            return new Yaml();
+        $this->app->bind(Parser::class, SymfonyParser::class);
+        $this->app->singleton('pragmarx.yaml', function ($app) {
+            return new Yaml(null, $app->make(Parser::class), null);
         });
     }
 }

--- a/src/package/Support/Parser.php
+++ b/src/package/Support/Parser.php
@@ -2,12 +2,12 @@
 
 namespace PragmaRX\Yaml\Package\Support;
 
-use Illuminate\Support\Collection;
 use PragmaRX\Yaml\Package\Exceptions\InvalidYamlFile;
-use Symfony\Component\Yaml\Parser as SymfonyParser;
-use Symfony\Component\Yaml\Yaml as SymfonyYaml;
 
-class Parser
+/**
+ * @codeCoverageIgnore
+ */
+interface Parser
 {
     /**
      * Dump array to yaml.InvalidYamlFile.
@@ -19,10 +19,7 @@ class Parser
      *
      * @return string
      */
-    public function dump($input, $inline = 5, $indent = 4, $flags = 0)
-    {
-        return SymfonyYaml::dump($input, $inline, $indent, $flags);
-    }
+    public function dump($input, $inline = 5, $indent = 4, $flags = 0);
 
     /**
      * Parse a yaml file.
@@ -33,12 +30,7 @@ class Parser
      *
      * @return mixed
      */
-    public function parse($contents)
-    {
-        return $this->checkYaml(
-            SymfonyYaml::parse($contents)
-        );
-    }
+    public function parse($contents);
 
     /**
      * Check parsed contents.
@@ -49,14 +41,7 @@ class Parser
      *
      * @return array
      */
-    public function checkYaml($contents)
-    {
-        if (is_string($contents)) {
-            throw new InvalidYamlFile();
-        }
-
-        return $contents;
-    }
+    public function checkYaml($contents);
 
     /**
      * Parses a YAML file into a PHP value.
@@ -68,20 +53,7 @@ class Parser
      *
      * @return mixed The YAML converted to a PHP value
      */
-    public function parseFile($filename, $flags = 0)
-    {
-        try {
-            return $this->checkYaml(
-                (new SymfonyParser())->parseFile($filename, $flags)
-            );
-        } catch (\Symfony\Component\Yaml\Exception\ParseException $exception) {
-            throw new InvalidYamlFile(
-                sprintf('%s is not valid YAML: %s', $filename, $exception->getMessage()),
-                $exception->getCode(),
-                $exception
-            );
-        }
-    }
+    public function parseFile($filename, $flags = 0);
 
     /**
      * Convert array to yaml and save.
@@ -89,12 +61,5 @@ class Parser
      * @param $array array
      * @param $file string
      */
-    public function saveAsYaml($array, $file, $inline = 2, $indent = 4, $flags = 0)
-    {
-        $array = $array instanceof Collection
-            ? $array->toArray()
-            : (array) $array;
-
-        file_put_contents($file, SymfonyYaml::dump($array, $inline, $indent, $flags));
-    }
+    public function saveAsYaml($array, $file, $inline = 2, $indent = 4, $flags = 0);
 }

--- a/src/package/Support/PeclParser.php
+++ b/src/package/Support/PeclParser.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace PragmaRX\Yaml\Package\Support;
+
+use Illuminate\Support\Collection;
+use PragmaRX\Yaml\Package\Exceptions\InvalidYamlFile;
+
+class PeclParser implements Parser
+{
+    /**
+     * Dump array to yaml.InvalidYamlFile.
+     *
+     * @param $input
+     * @param int $inline
+     * @param int $indent
+     * @param int $flags
+     *
+     * @return string
+     */
+    public function dump($input, $inline = 5, $indent = 4, $flags = 0)
+    {
+        $initialIndent = ini_set('yaml.output_indent', $indent);
+
+        $yaml = yaml_emit($input);
+        $yaml = ltrim($yaml, '---'.PHP_EOL);
+        $yaml = rtrim($yaml, '\.\.\.'.PHP_EOL);
+
+        ini_set('yaml.output_indent', $initialIndent);
+
+        return $yaml;
+    }
+
+    /**
+     * Parse a yaml file.
+     *
+     * @param $contents
+     *
+     * @throws InvalidYamlFile
+     *
+     * @return mixed
+     */
+    public function parse($contents)
+    {
+        return $this->checkYaml(
+            yaml_parse($contents)
+        );
+    }
+
+    /**
+     * Check parsed contents.
+     *
+     * @param $contents
+     *
+     * @throws InvalidYamlFile
+     *
+     * @return array
+     */
+    public function checkYaml($contents)
+    {
+        if (is_string($contents)) {
+            throw new InvalidYamlFile();
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Parses a YAML file into a PHP value.
+     *
+     * @param string $filename The path to the YAML file to be parsed
+     * @param int    $flags    A bit field of PARSE_* constants to customize the YAML parser behavior
+     *
+     * @throws \PragmaRX\Yaml\Package\Exceptions\InvalidYamlFile If the file could not be read or the YAML is not valid
+     *
+     * @return mixed The YAML converted to a PHP value
+     */
+    public function parseFile($filename, $flags = 0)
+    {
+        try {
+            $initialFlags = ini_set('yaml.decode_php', $flags);
+
+            return $this->checkYaml(
+                yaml_parse_file($filename)
+            );
+        } catch (\ErrorException $exception) {
+            throw new InvalidYamlFile(
+                sprintf('%s is not valid YAML: %s', $filename, $exception->getMessage()),
+                $exception->getCode(),
+                $exception
+            );
+        } finally {
+            ini_set('yaml.decode_php', $initialFlags);
+        }
+    }
+
+    /**
+     * Convert array to yaml and save.
+     *
+     * @param $array array
+     * @param $file string
+     */
+    public function saveAsYaml($array, $file, $inline = 2, $indent = 4, $flags = 0)
+    {
+        $array = $array instanceof Collection
+            ? $array->toArray()
+            : (array) $array;
+
+        file_put_contents($file, $this->dump($array, $inline, $indent, $flags));
+    }
+}

--- a/src/package/Support/SymfonyParser.php
+++ b/src/package/Support/SymfonyParser.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace PragmaRX\Yaml\Package\Support;
+
+use Illuminate\Support\Collection;
+use PragmaRX\Yaml\Package\Exceptions\InvalidYamlFile;
+use Symfony\Component\Yaml\Parser as BaseSymfonyParser;
+use Symfony\Component\Yaml\Yaml as SymfonyYaml;
+
+class SymfonyParser implements Parser
+{
+    /**
+     * Dump array to yaml.InvalidYamlFile.
+     *
+     * @param $input
+     * @param int $inline
+     * @param int $indent
+     * @param int $flags
+     *
+     * @return string
+     */
+    public function dump($input, $inline = 5, $indent = 4, $flags = 0)
+    {
+        return SymfonyYaml::dump($input, $inline, $indent, $flags);
+    }
+
+    /**
+     * Parse a yaml file.
+     *
+     * @param $contents
+     *
+     * @throws InvalidYamlFile
+     *
+     * @return mixed
+     */
+    public function parse($contents)
+    {
+        return $this->checkYaml(
+            SymfonyYaml::parse($contents)
+        );
+    }
+
+    /**
+     * Check parsed contents.
+     *
+     * @param $contents
+     *
+     * @throws InvalidYamlFile
+     *
+     * @return array
+     */
+    public function checkYaml($contents)
+    {
+        if (is_string($contents)) {
+            throw new InvalidYamlFile();
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Parses a YAML file into a PHP value.
+     *
+     * @param string $filename The path to the YAML file to be parsed
+     * @param int    $flags    A bit field of PARSE_* constants to customize the YAML parser behavior
+     *
+     * @throws \PragmaRX\Yaml\Package\Exceptions\InvalidYamlFile If the file could not be read or the YAML is not valid
+     *
+     * @return mixed The YAML converted to a PHP value
+     */
+    public function parseFile($filename, $flags = 0)
+    {
+        try {
+            return $this->checkYaml(
+                (new BaseSymfonyParser())->parseFile($filename, $flags)
+            );
+        } catch (\Symfony\Component\Yaml\Exception\ParseException $exception) {
+            throw new InvalidYamlFile(
+                sprintf('%s is not valid YAML: %s', $filename, $exception->getMessage()),
+                $exception->getCode(),
+                $exception
+            );
+        }
+    }
+
+    /**
+     * Convert array to yaml and save.
+     *
+     * @param $array array
+     * @param $file string
+     */
+    public function saveAsYaml($array, $file, $inline = 2, $indent = 4, $flags = 0)
+    {
+        $array = $array instanceof Collection
+            ? $array->toArray()
+            : (array) $array;
+
+        file_put_contents($file, SymfonyYaml::dump($array, $inline, $indent, $flags));
+    }
+}

--- a/src/package/Yaml.php
+++ b/src/package/Yaml.php
@@ -7,6 +7,7 @@ use PragmaRX\Yaml\Package\Exceptions\MethodNotFound;
 use PragmaRX\Yaml\Package\Support\File;
 use PragmaRX\Yaml\Package\Support\Parser;
 use PragmaRX\Yaml\Package\Support\Resolver;
+use PragmaRX\Yaml\Package\Support\SymfonyParser;
 
 class Yaml
 {
@@ -54,7 +55,7 @@ class Yaml
     {
         $this->instantiateClass($file, 'file', File::class);
 
-        $this->instantiateClass($parser, 'parser', Parser::class);
+        $this->instantiateClass($parser, 'parser', SymfonyParser::class);
 
         $this->instantiateClass($resolver, 'resolver', Resolver::class);
     }

--- a/tests/CommonYamlTests.php
+++ b/tests/CommonYamlTests.php
@@ -6,10 +6,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use PragmaRX\Yaml\Package\Exceptions\InvalidYamlFile;
 use PragmaRX\Yaml\Package\Exceptions\MethodNotFound;
-use PragmaRX\Yaml\Package\Facade as YamlFacade;
 use PragmaRX\Yaml\Package\Yaml as YamlService;
 
-class YamlTest extends TestCase
+trait CommonYamlTests
 {
     /**
      * @var YamlService
@@ -25,17 +24,6 @@ class YamlTest extends TestCase
      * @var Collection
      */
     private $multiple;
-
-    public function setUp(): void
-    {
-        parent::setup();
-
-        $this->yaml = YamlFacade::instance();
-
-        $this->multiple = $this->yaml->loadToConfig(__DIR__.'/stubs/conf/multiple', 'multiple');
-
-        $this->single = $this->yaml->loadToConfig(__DIR__.'/stubs/conf/single/single-app.yml', 'single');
-    }
 
     public function test_can_instantiate_service()
     {

--- a/tests/PeclYamlTest.php
+++ b/tests/PeclYamlTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PragmaRX\Yaml\Tests;
+
+use PragmaRX\Yaml\Package\Facade as YamlFacade;
+use PragmaRX\Yaml\Package\Support\Parser;
+use PragmaRX\Yaml\Package\Support\PeclParser;
+
+class PeclYamlTest extends TestCase
+{
+    use CommonYamlTests;
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $this->app->bind(Parser::class, PeclParser::class);
+        $this->yaml = YamlFacade::instance();
+
+        $this->multiple = $this->yaml->loadToConfig(__DIR__.'/stubs/conf/multiple', 'multiple');
+
+        $this->single = $this->yaml->loadToConfig(__DIR__.'/stubs/conf/single/single-app.yml', 'single');
+    }
+}

--- a/tests/PeclYamlTest.php
+++ b/tests/PeclYamlTest.php
@@ -12,6 +12,10 @@ class PeclYamlTest extends TestCase
 
     public function setUp(): void
     {
+        if (!extension_loaded('yaml')) {
+            $this->markTestSkipped('The PECL YAML extension is not available.');
+        }
+
         parent::setup();
 
         $this->app->bind(Parser::class, PeclParser::class);

--- a/tests/SymfonyYamlTest.php
+++ b/tests/SymfonyYamlTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PragmaRX\Yaml\Tests;
+
+use PragmaRX\Yaml\Package\Facade as YamlFacade;
+
+class SymfonyYamlTest extends TestCase
+{
+    use CommonYamlTests;
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $this->yaml = YamlFacade::instance();
+
+        $this->multiple = $this->yaml->loadToConfig(__DIR__.'/stubs/conf/multiple', 'multiple');
+
+        $this->single = $this->yaml->loadToConfig(__DIR__.'/stubs/conf/single/single-app.yml', 'single');
+    }
+}


### PR DESCRIPTION
I would like to add support for the PECL YAML because I want more speed.
This feature is optional and the default is disabled.

When I enabled the PECL YAML in addition to #18, the `Yaml::loadToConfig` method was less than _0.1 seconds_.