### PR TITLE
Do not load when the configuration is cached

### DIFF
--- a/src/package/Yaml.php
+++ b/src/package/Yaml.php
@@ -2,6 +2,7 @@
 
 namespace PragmaRX\Yaml\Package;
 
+use App;
 use Illuminate\Support\Collection;
 use PragmaRX\Yaml\Package\Exceptions\MethodNotFound;
 use PragmaRX\Yaml\Package\Support\File;
@@ -108,6 +109,10 @@ class Yaml
      */
     public function loadToConfig($path, $configKey)
     {
+        if (App::configurationIsCached()) {
+            return collect();
+        }
+
         $loaded = $this->file->isYamlFile($path)
             ? $this->loadFile($path)
             : $this->loadFromDirectory($path);

--- a/tests/CommonYamlTests.php
+++ b/tests/CommonYamlTests.php
@@ -2,6 +2,7 @@
 
 namespace PragmaRX\Yaml\Tests;
 
+use App;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use PragmaRX\Yaml\Package\Exceptions\InvalidYamlFile;
@@ -121,6 +122,15 @@ trait CommonYamlTests
         $this->expectException(MethodNotFound::class);
 
         $this->yaml->inexistentMethod();
+    }
+
+    public function test_do_not_load_when_configuration_is_cached()
+    {
+        App::shouldReceive('configurationIsCached')->andReturn(true);
+
+        $loaded = $this->yaml->loadToConfig(__DIR__.'/stubs/conf/single', 'single');
+
+        $this->assertEmpty($loaded);
     }
 
     public function cleanYamlString($string)


### PR DESCRIPTION
After using the `artisan config:cache` command, I want the `loadToConfig` method to not load anything because the configuration is already loaded.