### PR TITLE
PHP8.4 Deprecated

### DIFF
--- a/src/package/Yaml.php
+++ b/src/package/Yaml.php
@@ -48,7 +48,7 @@ class Yaml
      * @param Parser|null   $parser
      * @param Resolver|null $resolver
      */
-    public function __construct(File $file = null, Parser $parser = null, Resolver $resolver = null)
+    public function __construct(?File $file, ?Parser $parser, ?Resolver $resolver)
     {
         $this->instantiate($file, $parser, $resolver);
     }


### PR DESCRIPTION
Implicitly marking parameter `$file`, `$parser` and `$resolver` as nullable is deprecated. The explicit nullable type must be used instead.